### PR TITLE
BUFF-4500: make AUTO_ENSURE work again

### DIFF
--- a/mongorm/DocumentMetaclass.py
+++ b/mongorm/DocumentMetaclass.py
@@ -71,11 +71,7 @@ class DocumentMetaclass(type):
 				primaryKey = field
 			if value.unique:
 				keyOpts = { 'unique': True }
-				
-				if value.dropDups:
-					keyOpts['dropDups'] = True
-				
-				connection.stagedIndexes.append( (collection, indexConverter( field ), keyOpts) )
+				connection.stagedIndexes.append( (collection, [(indexConverter( field ), 1)], keyOpts) )
 		
 		# add a primary key if none exists and one is required
 		if needsPrimaryKey and primaryKey is None:

--- a/mongorm/connection.py
+++ b/mongorm/connection.py
@@ -29,6 +29,9 @@ def connect( databaseName, autoEnsure=False, wrapPymongo=None, **kwargs ):
 	connection = None
 	database = None
 
+	# Initialise connection and ensure indexes if configured
+	getDatabase()
+
 def getConnection( ):
 	global database, connection, connectionSettings
 

--- a/mongorm/fields/BaseField.py
+++ b/mongorm/fields/BaseField.py
@@ -1,10 +1,9 @@
 class BaseField(object):
 	_resyncAtSave = False
 	
-	def __init__( self, default=None, unique=False, dbField=None, primaryKey=False, dropDups=False ):
+	def __init__( self, default=None, unique=False, dbField=None, primaryKey=False ):
 		self.default = default
 		self.unique = unique
-		self.dropDups = dropDups
 		self.dbField = dbField
 		self.primaryKey = primaryKey
 		if primaryKey:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='mongorm',
-      version='0.5.9.2',
+      version='0.5.9.3',
       packages=find_packages(),
       author='Theo Julienne, John Garland',
       author_email='theo@icy.com.au, john@openlearning.com',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='mongorm',
-      version='0.5.9.3',
+      version='0.5.9.4',
       packages=find_packages(),
       author='Theo Julienne, John Garland',
       author_email='theo@icy.com.au, john@openlearning.com',


### PR DESCRIPTION
- Call `getDatabase()` in `connect` to ensure that it actually does get called, and everything is initialised eagerly
- Remove deprecated `dropDups` key
- Refactor `ensureIndexes` so that it works correctly, and so that it doesn't do a separate MongoDB API call for each index (just 2 for each collection)